### PR TITLE
Add arXiv download script and downloaded file check

### DIFF
--- a/data_prep/arxiv/run_download.py
+++ b/data_prep/arxiv/run_download.py
@@ -5,6 +5,7 @@ import configparser
 import itertools
 import numpy as np
 import pathlib
+import os
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--aws_config', type=str, help='aws config file')
@@ -32,7 +33,7 @@ class ArxivDownloader:
             's3',  # the AWS resource we want to use
             aws_access_key_id=configs['DEFAULT']['ACCESS_KEY'],
             aws_secret_access_key=configs['DEFAULT']['SECRET_KEY'],
-            region_name='us-east-1'  # same region arxiv bucket is in
+            region_name='us-east-1',  # same region arxiv bucket is in      
         )
 
     def run(self, input_file: str, tgt_dir: pathlib.Path, max_files=-1):
@@ -51,8 +52,15 @@ class ArxivDownloader:
                 break
 
     def __download_file(self, key, tgt_dir: pathlib.Path):
+        filename = pathlib.Path(tgt_dir, key)
         print('\nDownloading s3://arxiv/{} t'
-              'o {}...'.format(key, pathlib.Path(tgt_dir, key)))
+              'o {}...'.format(key, filename))
+        
+        if filename.exists():
+            print(f'File {filename} already exists, skipping download...')
+            return
+        
+        print('\nDownloading s3://arxiv/{} to {}...'.format(key, filename))
 
         try:
             self.s3resource.meta.client.download_file(

--- a/data_prep/arxiv/scripts/arxiv-single-download.sh
+++ b/data_prep/arxiv/scripts/arxiv-single-download.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# for download partitions
+# and then filter paper before 2021
+
+set -e
+
+WORKERS=100
+
+export DATA_DIR="./data/arxiv"
+
+# setup partitions
+python run_download.py --aws_config aws_config.ini --workers $WORKERS --target_dir $DATA_DIR --setup
+
+# Function to process a file
+process_file() {
+    INPUT_FILE="$1"
+    echo "Processing input file is ${INPUT_FILE}"
+    python run_download.py --aws_config aws_config.ini --target_dir $DATA_DIR --input $INPUT_FILE
+}
+
+# Export the function to be used by xargs
+export -f process_file
+
+ls ${DATA_DIR}/partitions/*.txt | xargs -I {} -P 8 -n 1 bash -c 'process_file "$@"' _ {}
+


### PR DESCRIPTION
1. adding  a script that could be running without slurm
2. adding a downloaded file check, save aws costs by checking if files have already been downloaded before downloads